### PR TITLE
feat: support stylist time off blocks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Payment Configuration
+CASHAPP_HANDLE=
+DEPOSIT_AMOUNT=15
+
+# Airtable Configuration (Required)
+AIRTABLE_ACCESS_TOKEN=
+AIRTABLE_BASE_ID=
+AIRTABLE_BOOKING_TABLE_ID=
+AIRTABLE_WEEKLY_SCHEDULE_TABLE_ID=
+AIRTABLE_TIME_OFF_TABLE_ID=
+
+# Required Airtable Field Names
+BOOKING_DATE_FIELD=Preferred Date
+BOOKING_STATUS_FIELD=Booking Status
+BOOKING_START_TIME_FIELD=Preferred Time
+
+# App Configuration (Server-side only)
+SITE_TZ=America/Chicago
+POLLING_INTERVAL_MINUTES=5

--- a/README.md
+++ b/README.md
@@ -39,13 +39,15 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 The app can block personal time that the stylist is unavailable. In your Airtable base create a table named **`Stylist Time Off`** with the following fields:
 
-| Field        | Type                        | Description                                      |
-| ------------ | --------------------------- | ------------------------------------------------ |
-| `Date`       | Date                        | Day the stylist is unavailable                   |
-| `Start Time` | Single line text            | Beginning of the blocked period (e.g. "1:30 PM") |
-| `End Time`   | Single line text            | End of the blocked period (e.g. "3:00 PM")       |
-| `Notes`      | Single line text (optional) | Reason or comment                                |
+| Field        | Type                        | Description                                       |
+| ------------ | --------------------------- | ------------------------------------------------- |
+| `Date`       | Date                        | Day the stylist is unavailable                    |
+| `Start Time` | Single line text            | Beginning of the blocked period (e.g. "10:00 AM") |
+| `End Time`   | Single line text            | End of the blocked period (e.g. "5:00 PM")        |
+| `Notes`      | Single line text (optional) | Reason or comment                                 |
 
 It's fine to use the `Date` field as the table's primary column.
+
+Enter times in 12-hour format using AM/PM.
 
 Set the `AIRTABLE_TIME_OFF_TABLE_ID` environment variable to the ID of this table. Any record added here will prevent bookings during the specified times.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 The app can block personal time that the stylist is unavailable. In your Airtable base create a table named **`Stylist Time Off`** with the following fields:
 
-| Field   | Type                        | Description                     |
-| ------- | --------------------------- | ------------------------------- |
-| `Date`  | Date                        | Day the stylist is unavailable  |
-| `Start` | Time                        | Beginning of the blocked period |
-| `End`   | Time                        | End of the blocked period       |
-| `Notes` | Single line text (optional) | Reason or comment               |
+| Field        | Type                        | Description                                      |
+| ------------ | --------------------------- | ------------------------------------------------ |
+| `Date`       | Date                        | Day the stylist is unavailable                   |
+| `Start Time` | Single line text            | Beginning of the blocked period (e.g. "1:30 PM") |
+| `End Time`   | Single line text            | End of the blocked period (e.g. "3:00 PM")       |
+| `Notes`      | Single line text (optional) | Reason or comment                                |
+
+It's fine to use the `Date` field as the table's primary column.
 
 Set the `AIRTABLE_TIME_OFF_TABLE_ID` environment variable to the ID of this table. Any record added here will prevent bookings during the specified times.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,16 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Stylist Time Off
+
+The app can block personal time that the stylist is unavailable. In your Airtable base create a table named **`Stylist Time Off`** with the following fields:
+
+| Field   | Type                        | Description                     |
+| ------- | --------------------------- | ------------------------------- |
+| `Date`  | Date                        | Day the stylist is unavailable  |
+| `Start` | Time                        | Beginning of the blocked period |
+| `End`   | Time                        | End of the blocked period       |
+| `Notes` | Single line text (optional) | Reason or comment               |
+
+Set the `AIRTABLE_TIME_OFF_TABLE_ID` environment variable to the ID of this table. Any record added here will prevent bookings during the specified times.

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -21,6 +21,9 @@ const serverSchema = z.object({
   AIRTABLE_WEEKLY_SCHEDULE_TABLE_ID: z
     .string()
     .min(1, 'Airtable weekly schedule table ID must be a non-empty string'),
+  AIRTABLE_TIME_OFF_TABLE_ID: z
+    .string()
+    .min(1, 'Airtable time off table ID must be a non-empty string'),
 
   // **Required** Airtable Field Names
   // These MUST match the exact names in your Airtable base.

--- a/src/lib/services/airtable.ts
+++ b/src/lib/services/airtable.ts
@@ -184,22 +184,39 @@ export class AirtableBookingService {
     const dateStr = date.toISOString().split('T')[0];
     const formula = `IS_SAME({${TF.date}}, '${dateStr}', 'day')`;
 
+    console.log(`Querying time-off with formula: ${formula}`);
+
     const records = await this.timeOffTable
       .select({ filterByFormula: formula })
       .all();
 
-    return records.map(record => ({
-      id: record.id,
-      startTime: this.combineDateAndTime(
-        dateStr,
-        record.fields[TF.startTime] as string
-      ),
-      endTime: this.combineDateAndTime(
-        dateStr,
-        record.fields[TF.endTime] as string
-      ),
-      note: record.fields[TF.notes] as string | undefined,
-    }));
+    console.log(`Found ${records.length} time-off records`);
+
+    return records.map(record => {
+      const startTimeStr = record.fields[TF.startTime] as string;
+      const endTimeStr = record.fields[TF.endTime] as string;
+
+      console.log(`Processing time-off record ${record.id}:`);
+      console.log(`  Raw start time: "${startTimeStr}"`);
+      console.log(`  Raw end time: "${endTimeStr}"`);
+
+      const startTime = this.combineDateAndTime(dateStr, startTimeStr);
+      const endTime = this.combineDateAndTime(dateStr, endTimeStr);
+
+      console.log(
+        `  Parsed start time: ${startTime.toISOString()} (${startTime.toLocaleTimeString()})`
+      );
+      console.log(
+        `  Parsed end time: ${endTime.toISOString()} (${endTime.toLocaleTimeString()})`
+      );
+
+      return {
+        id: record.id,
+        startTime,
+        endTime,
+        note: record.fields[TF.notes] as string | undefined,
+      };
+    });
   }
 
   // --- Schedule Operations ---
@@ -238,22 +255,52 @@ export class AirtableBookingService {
   }
 
   private combineDateAndTime(dateStr?: string, timeStr?: string): Date {
-    if (!dateStr || !timeStr) return new Date();
+    if (!dateStr || !timeStr) {
+      console.log(
+        `combineDateAndTime: Missing params - dateStr: "${dateStr}", timeStr: "${timeStr}"`
+      );
+      return new Date();
+    }
 
+    console.log(
+      `combineDateAndTime: Processing dateStr: "${dateStr}", timeStr: "${timeStr}"`
+    );
     const [hours, minutes] = this.parseTimeString(timeStr);
-    const date = new Date(dateStr);
-    date.setHours(hours, minutes, 0, 0);
+    console.log(
+      `combineDateAndTime: Parsed hours: ${hours}, minutes: ${minutes}`
+    );
+
+    // Fix: Create date in local timezone to avoid date shifts
+    const [year, month, day] = dateStr.split('-').map(Number);
+    const date = new Date(year, month - 1, day, hours, minutes, 0, 0);
+
+    console.log(
+      `combineDateAndTime: Final result: ${date.toISOString()} (${date.toLocaleTimeString()})`
+    );
+    console.log(
+      `combineDateAndTime: Date components - Year: ${year}, Month: ${month - 1}, Day: ${day}`
+    );
     return date;
   }
 
   private parseTimeString(timeStr: string): [number, number] {
+    console.log(`parseTimeString: Parsing "${timeStr}"`);
+
+    // Try parsing as ISO date first
     const iso = new Date(timeStr);
     if (!isNaN(iso.getTime())) {
+      console.log(
+        `parseTimeString: Parsed as ISO date - hours: ${iso.getHours()}, minutes: ${iso.getMinutes()}`
+      );
       return [iso.getHours(), iso.getMinutes()];
     }
 
+    // Try parsing as AM/PM format
     const match = timeStr.trim().match(/(\d{1,2})(?::(\d{2}))?\s*(AM|PM)/i);
     if (!match) {
+      console.log(
+        `parseTimeString: No match found for "${timeStr}", returning [0, 0]`
+      );
       return [0, 0];
     }
 
@@ -261,9 +308,16 @@ export class AirtableBookingService {
     const minutes = match[2] ? parseInt(match[2], 10) : 0;
     const period = match[3].toUpperCase();
 
+    console.log(
+      `parseTimeString: Matched - raw hours: ${hours}, minutes: ${minutes}, period: ${period}`
+    );
+
     if (period === 'PM' && hours !== 12) hours += 12;
     if (period === 'AM' && hours === 12) hours = 0;
 
+    console.log(
+      `parseTimeString: Final result - hours: ${hours}, minutes: ${minutes}`
+    );
     return [hours, minutes];
   }
 

--- a/src/lib/services/airtable.ts
+++ b/src/lib/services/airtable.ts
@@ -38,6 +38,13 @@ const F = {
   totalPrice: 'Total Price',
 } as const;
 
+const TF = {
+  date: 'Date',
+  startTime: 'Start Time',
+  endTime: 'End Time',
+  notes: 'Notes',
+} as const;
+
 export class AirtableBookingService {
   private base: Airtable.Base;
   private bookingTable: Airtable.Table<BookingFields>;
@@ -175,7 +182,7 @@ export class AirtableBookingService {
 
   async getTimeOffForDate(date: Date): Promise<TimeOff[]> {
     const dateStr = date.toISOString().split('T')[0];
-    const formula = `IS_SAME({Date}, '${dateStr}', 'day')`;
+    const formula = `IS_SAME({${TF.date}}, '${dateStr}', 'day')`;
 
     const records = await this.timeOffTable
       .select({ filterByFormula: formula })
@@ -185,10 +192,13 @@ export class AirtableBookingService {
       id: record.id,
       startTime: this.combineDateAndTime(
         dateStr,
-        record.fields['Start'] as string
+        record.fields[TF.startTime] as string
       ),
-      endTime: this.combineDateAndTime(dateStr, record.fields['End'] as string),
-      note: record.fields['Notes'] as string | undefined,
+      endTime: this.combineDateAndTime(
+        dateStr,
+        record.fields[TF.endTime] as string
+      ),
+      note: record.fields[TF.notes] as string | undefined,
     }));
   }
 

--- a/src/lib/services/airtable.ts
+++ b/src/lib/services/airtable.ts
@@ -251,15 +251,19 @@ export class AirtableBookingService {
     if (!isNaN(iso.getTime())) {
       return [iso.getHours(), iso.getMinutes()];
     }
-    const match = timeStr.match(/(\d+):(\d+)\s*(AM|PM)/i);
+
+    const match = timeStr.trim().match(/(\d{1,2})(?::(\d{2}))?\s*(AM|PM)/i);
     if (!match) {
       return [0, 0];
     }
+
     let hours = parseInt(match[1], 10);
-    const minutes = parseInt(match[2], 10);
+    const minutes = match[2] ? parseInt(match[2], 10) : 0;
     const period = match[3].toUpperCase();
+
     if (period === 'PM' && hours !== 12) hours += 12;
     if (period === 'AM' && hours === 12) hours = 0;
+
     return [hours, minutes];
   }
 

--- a/src/lib/services/availability.ts
+++ b/src/lib/services/availability.ts
@@ -67,15 +67,15 @@ class AvailabilityService {
       return [hours, minutes];
     }
 
-    // Fallback for "h:mm A" format
-    const time = timeStr.match(/(\d+):(\d+)\s*(AM|PM)/i);
+    // Fallback for 12-hour text like "h:mm AM" or "h AM"
+    const time = timeStr.trim().match(/(\d{1,2})(?::(\d{2}))?\s*(AM|PM)/i);
     if (!time) {
       console.error(`Invalid time format for: "${timeStr}"`);
       return [0, 0];
     }
 
     let hours = parseInt(time[1], 10);
-    const minutes = parseInt(time[2], 10);
+    const minutes = time[2] ? parseInt(time[2], 10) : 0;
     const period = time[3].toUpperCase();
 
     if (period === 'PM' && hours !== 12) {

--- a/src/lib/types/airtable.ts
+++ b/src/lib/types/airtable.ts
@@ -29,3 +29,12 @@ export interface ScheduleFields {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
+
+export interface TimeOffFields {
+  Date: string;
+  Start: string;
+  End: string;
+  Notes?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}

--- a/src/lib/types/airtable.ts
+++ b/src/lib/types/airtable.ts
@@ -32,8 +32,8 @@ export interface ScheduleFields {
 
 export interface TimeOffFields {
   Date: string;
-  Start: string;
-  End: string;
+  'Start Time': string;
+  'End Time': string;
   Notes?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;

--- a/src/lib/types/booking.ts
+++ b/src/lib/types/booking.ts
@@ -49,6 +49,13 @@ export interface Booking {
   updatedAt: Date;
 }
 
+export interface TimeOff {
+  id: string;
+  startTime: Date;
+  endTime: Date;
+  note?: string;
+}
+
 export type NewBooking = Omit<Booking, 'id' | 'createdAt' | 'updatedAt'>;
 
 export interface NotificationPayload {


### PR DESCRIPTION
## Summary
- add Airtable table support for stylist time off and expose `getTimeOffForDate`
- merge stylist time-off blocks into availability calculations
- document how to configure the Stylist Time Off table

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5fc1155b0832289d4ace533965ce2